### PR TITLE
ページ /site-map を追加

### DIFF
--- a/src/assets/styles/utilities/u-medium.css
+++ b/src/assets/styles/utilities/u-medium.css
@@ -29,4 +29,15 @@
     padding-top: 8px;
     margin: 0;
   }
+
+  a {
+    text-decoration: none;
+    color: var(--c-vue-green);
+    transition: color 0.25s;
+
+  &:hover {
+     text-decoration: none;
+     color: var(--c-vue-green-light);
+   }
+  }
 }

--- a/src/pages/site-map/index.vue
+++ b/src/pages/site-map/index.vue
@@ -1,0 +1,48 @@
+<template>
+  <AppPage class="SiteMap">
+    <LegalMedium title-ja="サイトマップ" title-en="Site Map">
+      <p>Vue.js 日本ユーザーグループの Web サイトのサイトマップを掲載しています。</p>
+
+      <h2>Vue.js 日本ユーザーグループについて</h2>
+      <nav>
+        <ul>
+          <li>
+            <NuxtLink class="u-link-text" to="/">Home</NuxtLink>
+          </li>
+          <li>
+            <NuxtLink class="u-link-text" to="/about">About</NuxtLink>
+          </li>
+        </ul>
+      </nav>
+
+      <h2>お問い合わせ</h2>
+      <nav>
+        <ul>
+          <li>
+            <NuxtLink class="u-link-text" to="/contact">Contact</NuxtLink>
+          </li>
+        </ul>
+      </nav>
+    </LegalMedium>
+  </AppPage>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import AppPage from '@/components/AppPage.vue'
+import LegalMedium from '@/components/LegalMedium.vue'
+
+export default Vue.extend({
+  components: {
+    AppPage,
+    LegalMedium
+  },
+
+  head: {
+    title: 'Site Map',
+    meta: [
+      { hid: 'description', name: 'description', content: 'Vue.js 日本ユーザーグループの Web サイトのサイトマップを掲載しています。' }
+    ]
+  }
+})
+</script>


### PR DESCRIPTION
Resolves #32 

`/site-map` としてサイトマップページを作成

## コンテンツ
現状デザインから拾えるページをコンテンツとしました。

## デザイン
@kiaking 
インブラウザでデザインしたため。独自スタイルは用意せず、leagal 周りのものを流用しました。

|375px|1111px|
|:--|:--|
|![192 168 100 103_3000_site-map (1)](https://user-images.githubusercontent.com/13103139/70621882-f8354b80-1c5d-11ea-8d29-80c301df8887.png)|![192 168 100 103_3000_site-map](https://user-images.githubusercontent.com/13103139/70621891-fa97a580-1c5d-11ea-9623-5421f9c6c039.png)|


## 懸念（提案）
@kiaking @kazupon 
現状のコンテンツ量と Vue.js 日本ユーザーグループ コミュニティの性質から、
グローバルヘッダーでその役割に応えられる良いサイト設計になっていると思いました！

今後も圧倒的なコンテンツ量になるような気はしておらず、
**サイト内よりはむしろ、外部へ目を向けたページに切り替えるのはいかがでしょうか？ 👀 **

例えば、connpass などイベント情報、SNSリンク、各リポジトリなど。
トップページ（HOME)に近いですが、それよりは簡素でさらに網羅的なものを想像しています。

曖昧な状態ですみません！
また、GitHub にあまり慣れないものでして、 issues に移行すべきだったりすれば手引きいただけると助かります 🙏 