### PR TITLE
refactor: add preloader until the image is loaded

### DIFF
--- a/src/components/ImageStack.vue
+++ b/src/components/ImageStack.vue
@@ -3,9 +3,7 @@
     <ul class="list" :style="{ paddingBottom: `${aspectRatio}%` }" role="button" @click="next">
       <TransitionGroup name="slide">
         <li v-for="(stack, i) in stacks" :key="stack.src" class="item" :class="`item-${i}`">
-          <figure class="figure">
-            <img class="img" :src="stack.src" :alt="stack.alt">
-          </figure>
+          <ImageStackItem :image="stack" />
         </li>
       </TransitionGroup>
     </ul>
@@ -38,6 +36,7 @@
 import Vue, { PropOptions } from 'vue'
 import IconChevronLeft from './icons/IconChevronLeft.vue'
 import IconChevronRight from './icons/IconChevronRight.vue'
+import ImageStackItem from './ImageStackItem.vue'
 
 interface Image {
   src: string
@@ -53,7 +52,8 @@ interface Classes {
 export default Vue.extend({
   components: {
     IconChevronLeft,
-    IconChevronRight
+    IconChevronRight,
+    ImageStackItem
   },
 
   props: {
@@ -218,8 +218,8 @@ export default Vue.extend({
   transform: translate(0, 0) scale(1);
 }
 
-.item-0 .figure { filter: blur(32px); }
-.item-1 .figure { filter: blur(16px); }
+.item-0 >>> .figure { filter: blur(32px); }
+.item-1 >>> .figure { filter: blur(16px); }
 
 .item-0.slide-enter,
 .item-0.slide-leave-to,
@@ -227,18 +227,6 @@ export default Vue.extend({
 .item-2.slide-leave-to {
   filter: blur(16px);
   opacity: 0;
-}
-
-.figure {
-  filter: blur(0);
-  transition: filter 0.75s;
-}
-
-.img {
-  width: 100%;
-  height: 100%;
-  border-radius: 8px;
-  object-fit: cover;
 }
 
 .control {

--- a/src/components/ImageStackItem.vue
+++ b/src/components/ImageStackItem.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="ImageStackItem">
+    <div class="loader" :class="{ loaded }">
+      <IconPreloaderDark class="loader-icon" />
+    </div>
+
+    <figure class="figure">
+      <img class="img" :src="image.src" :alt="image.alt" @load="loaded = true">
+    </figure>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropOptions } from 'vue'
+import IconPreloaderDark from './icons/IconPreloaderDark.vue'
+
+interface Image {
+  src: string
+  alt: string
+}
+
+export default Vue.extend({
+  components: {
+    IconPreloaderDark
+  },
+
+  props: {
+    image: { type: Object, required: true } as PropOptions<Image>
+  },
+
+  data () {
+    return {
+      loaded: false
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+@import '@/assets/styles/variables';
+
+.loader {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 20;
+  background-color: var(--c-white);
+}
+
+.loader-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 48px;
+  height: 48px;
+  transition: opacity 0.5s;
+  transform: translate(-50%);
+}
+
+.loader.loaded {
+  opacity: 0;
+}
+
+.figure {
+  position: relative;
+  z-index: 10;
+  filter: blur(0);
+  transition: filter 0.75s;
+}
+
+.img {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  object-fit: cover;
+}
+</style>

--- a/src/components/ImageStackItem.vue
+++ b/src/components/ImageStackItem.vue
@@ -32,6 +32,12 @@ export default Vue.extend({
     return {
       loaded: false
     }
+  },
+
+  mounted () {
+    // In case the image load event would not fire, we'll force displaying
+    // the image after 3 sec.
+    setTimeout(() => { this.loaded = true }, 3000)
   }
 })
 </script>
@@ -47,6 +53,11 @@ export default Vue.extend({
   left: 0;
   z-index: 20;
   background-color: var(--c-white);
+  transition: opacity 0.5s;
+}
+
+.loader.loaded {
+  opacity: 0;
 }
 
 .loader-icon {
@@ -55,12 +66,7 @@ export default Vue.extend({
   left: 50%;
   width: 48px;
   height: 48px;
-  transition: opacity 0.5s;
   transform: translate(-50%);
-}
-
-.loader.loaded {
-  opacity: 0;
 }
 
 .figure {


### PR DESCRIPTION
ImageStackの画像がロードされるまで、プリローダーを表示する。現在、ImageStackの画像が表示される時パッと表示されてしまってカッコ良くないので、これをスムーズにする。