### PR TITLE
fix: update nuxtjs translation project url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Vue.js に興味のある方でしたらどなたでもお気軽にご参加く�
 ## 活動
 
 - [Vue.js 公式ドキュメント 日本語翻訳プロジェクト](https://github.com/vuejs/jp.vuejs.org)
-- [Nuxt.js 公式ドキュメント 日本語翻訳プロジェクト](https://github.com/vuejs-jp/ja.docs.nuxtjs)
+- [Nuxt.js 公式ドキュメント 日本語翻訳プロジェクト](https://github.com/vuejs-jp/ja.nuxtjs.org/wiki)
 - [Vue.js Meetup イベント](http://vuejs-meetup.connpass.com)
 
 ## ツールスポンサー

--- a/src/components/HomeProjects.vue
+++ b/src/components/HomeProjects.vue
@@ -30,7 +30,7 @@
             </article>
           </a>
 
-          <a class="project" href="https://github.com/vuejs-jp/ja.docs.nuxtjs" target="_blank">
+          <a class="project" href="https://github.com/vuejs-jp/ja.nuxtjs.org/wiki" target="_blank">
             <article class="project-box">
               <i class="project-type">
                 <IconEdit3 class="project-icon" />


### PR DESCRIPTION
ドキュメントを管理するレポジトリが変更されたため（`docs.nuxtjs` -> `nuxtjs.org`）
README.md とサイト中の Nuxt.js 公式ドキュメント日本語翻訳プロジェクトの URL を変更しました。

また、変更により README に翻訳についての記述がなくなったので
README の代わりとして wiki を表示するようにしています。

@inouetakuya @53able 