### PR TITLE
fix: vuejs-jp slack join URL の変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Vue.js に興味のある方でしたらどなたでもお気軽にご参加く�
 ## コミュニケーション
 
 - [Vue.js オフィシャルフォーラム](http://forum.vuejs.org)
-- [Vue.js 日本ユーザーグループ 公式 Slack](https://vuejs-jp-slackin.herokuapp.com)
+- [Vue.js 日本ユーザーグループ 公式 Slack](https://join.slack.com/t/vuejs-jp/shared_invite/zt-pcpd1rnq-QTaoQ0U_gRiewCsyO6NH8Q)
 - [Vue.js 日本ユーザーグループ 公式 Twitter](https://twitter.com/vuefes)
 - [Vue.js 日本ユーザーグループ 公式 note](https://note.com/vuejs_jp)
 

--- a/src/components/HomeCommunications.vue
+++ b/src/components/HomeCommunications.vue
@@ -22,7 +22,7 @@
             <ButtonOutline
               tag="a"
               :block="true"
-              href="https://vuejs-jp-slackin.herokuapp.com/"
+              href="https://join.slack.com/t/vuejs-jp/shared_invite/zt-pcpd1rnq-QTaoQ0U_gRiewCsyO6NH8Q"
               :icon="iconSlack"
               label="Slackに参加する"
             />

--- a/src/pages/contact/index.vue
+++ b/src/pages/contact/index.vue
@@ -19,7 +19,7 @@
 
           <ul class="actions">
             <li class="action">
-              <a class="action-link" href="https://vuejs-jp-slackin.herokuapp.com/" target="_blank" rel="noopener noreferrer">
+              <a class="action-link" href="https://join.slack.com/t/vuejs-jp/shared_invite/zt-pcpd1rnq-QTaoQ0U_gRiewCsyO6NH8Q" target="_blank" rel="noopener noreferrer">
                 <IconSlack class="action-icon slack" />
                 Slackで質問する
                 <IconChevronRight class="action-chevron" />


### PR DESCRIPTION
## 背景
- Vue.js 日本ユーザーグループの Slack へ join するために用意していた、slackin が slack api で使用していた legacy api token が初期化？されてしまったため、join できない状態になっていた
- legacy api token の再発行を試みたが、現在 slack api はもうすでに発行出来ない状態になっているため、slackin が復旧できない状態に
- 現状 slackin は slack apps (現在 slack api は slack apps に登録が必須) に対応していないため、slack apps 経由で slack api を使って提供することはできない状態

## 対応方法
- slack にユーザーを招待させるために、招待 URL を発行出来る仕組みが提供されているため、この方法で解決する

## 懸念点
- 発行した招待 URL の有効期限がはっきりしていない。招待 URL の設定で never expiration にしてあるが、発行されている招待 URL がnever になっているのかどうか分からない
