### PR TITLE
日本語ドキュメントリポジトリの URL を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Vue.js に興味のある方でしたらどなたでもお気軽にご参加く�
 
 ## 活動
 
-- [Vue.js 公式ドキュメント 日本語翻訳プロジェクト](https://github.com/vuejs-jp/ja.vuejs.org)
+- [Vue.js 公式ドキュメント 日本語翻訳プロジェクト](https://github.com/vuejs-translations/docs-ja)
 - [Nuxt.js 公式ドキュメント 日本語翻訳プロジェクト](https://github.com/vuejs-jp/ja.nuxtjs.org/wiki)
 - [Vue.js Meetup イベント](http://vuejs-meetup.connpass.com)
 

--- a/components/HomeProjects.vue
+++ b/components/HomeProjects.vue
@@ -14,7 +14,7 @@
 
       <div class="projects">
         <div class="projects-container">
-          <a class="project" href="https://github.com/vuejs-jp/ja.vuejs.org" target="_blank">
+          <a class="project" href="https://github.com/vuejs-translations/docs-ja" target="_blank">
             <article class="project-box">
               <i class="project-type">
                 <IconEdit3 class="project-icon" />


### PR DESCRIPTION
日本語ドキュメントのリポジトリ URL が古かったので、現在の URL に更新しました